### PR TITLE
Add GitHub automation script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,20 @@
 # codex-lab-harli
+
+This repository contains utilities to automate GitHub tasks using Python. The `scripts` directory includes a script to create a repository and upload a README file via the GitHub API.
+
+## Usage
+
+1. Install the dependencies:
+   ```bash
+   pip install requests
+   ```
+2. Export the following environment variables:
+   - `GITHUB_USERNAME`: your GitHub username.
+   - `REPO_NAME`: name of the repository to create.
+   - `GITHUB_TOKEN`: a GitHub personal access token with repo permissions.
+3. Run the script:
+   ```bash
+   python scripts/create_repo.py
+   ```
+
+The script creates the repository and adds a README with predefined content.

--- a/scripts/create_repo.py
+++ b/scripts/create_repo.py
@@ -1,0 +1,55 @@
+import os
+import base64
+import requests
+
+GITHUB_USERNAME = os.getenv('GITHUB_USERNAME')
+REPO_NAME = os.getenv('REPO_NAME')
+TOKEN = os.getenv('GITHUB_TOKEN')
+
+README_CONTENT = """# QG IA STRATEGIQUE
+
+Bienvenue dans le centre névralgique de l’orchestration IA signée Harli ∞ Mind. 🚀
+Ce dépôt contient :
+- L’arborescence Notion
+- Les agents intelligents actifs
+- Les templates & prompts
+- Les dashboards (PNB, CIC, ALM)
+"""
+
+def create_repo():
+    url = 'https://api.github.com/user/repos'
+    headers = {'Authorization': f'token {TOKEN}',
+               'Accept': 'application/vnd.github.v3+json'}
+    data = {'name': REPO_NAME,
+            'private': False,
+            'auto_init': False}
+    response = requests.post(url, headers=headers, json=data)
+    if response.status_code == 201:
+        print('\u2714\ufe0f Dépôt créé')
+        return True
+    else:
+        print(response.json())
+        return False
+
+def create_readme():
+    create_readme_url = f'https://api.github.com/repos/{GITHUB_USERNAME}/{REPO_NAME}/contents/README.md'
+    headers = {'Authorization': f'token {TOKEN}',
+               'Accept': 'application/vnd.github.v3+json'}
+    encoded_readme = base64.b64encode(README_CONTENT.encode('utf-8')).decode('utf-8')
+    data = {
+        'message': 'Ajout du README initial',
+        'content': encoded_readme,
+        'branch': 'main'
+    }
+    r = requests.put(create_readme_url, headers=headers, json=data)
+    if r.status_code == 201:
+        print('\ud83d\udcd8 README ajouté')
+    else:
+        print(r.json())
+
+if __name__ == '__main__':
+    if not all([GITHUB_USERNAME, REPO_NAME, TOKEN]):
+        print('Configurez GITHUB_USERNAME, REPO_NAME et GITHUB_TOKEN en variables d\'environnement.')
+    else:
+        if create_repo():
+            create_readme()


### PR DESCRIPTION
## Summary
- add a script to automate creating a GitHub repo and README
- update README with usage instructions

## Testing
- `python scripts/create_repo.py` *(fails: ModuleNotFoundError: No module named 'requests')*
- `pip install requests` *(fails: cannot connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684cb5d49e48832e8b546e33f6508231